### PR TITLE
Update QueryCursor API to match Rust library to enable filtering predicates by default

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -957,7 +957,7 @@ func (qc *QueryCursor) nextMatch(filterPredicates bool) (*QueryMatch, bool) {
 	}
 
 	if filterPredicates {
-		qm = qc.FilterPredicates(qm)
+		qm = qc.filterPredicates(qm)
 	}
 	return qm, true
 }
@@ -992,7 +992,7 @@ func (qc *QueryCursor) NextCapture() (*QueryMatch, uint32, bool) {
 	return qm, uint32(captureIndex), true
 }
 
-func (qc *QueryCursor) FilterPredicates(m *QueryMatch) *QueryMatch {
+func (qc *QueryCursor) filterPredicates(m *QueryMatch) *QueryMatch {
 	qm := &QueryMatch{
 		ID:           m.ID,
 		PatternIndex: m.PatternIndex,

--- a/bindings.go
+++ b/bindings.go
@@ -260,7 +260,8 @@ type Tree struct {
 // Copy returns a new copy of a tree
 func (t *Tree) Copy() *Tree {
 	nt := t.p.newTree(C.ts_tree_copy(t.c))
-	nt.input = t.input
+	nt.input = make([]byte, len(t.input))
+	copy(nt.input, t.input)
 	return nt
 }
 

--- a/bindings.go
+++ b/bindings.go
@@ -260,8 +260,7 @@ type Tree struct {
 // Copy returns a new copy of a tree
 func (t *Tree) Copy() *Tree {
 	nt := t.p.newTree(C.ts_tree_copy(t.c))
-	nt.input = make([]byte, len(t.input))
-	copy(nt.input, t.input)
+	nt.input = t.input
 	return nt
 }
 

--- a/bindings.go
+++ b/bindings.go
@@ -865,7 +865,7 @@ func NewQueryCursor() *QueryCursor {
 }
 
 // Exec executes the query on a given syntax node.
-func (qc *QueryCursor) Exec(q *Query, n *Node, text []byte) {
+func (qc *QueryCursor) Exec(q *Query, n *Node) {
 	qc.q = q
 	qc.t = n.t
 	C.ts_query_cursor_exec(qc.c, q.c, n.c)

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -350,7 +350,7 @@ func TestQuery(t *testing.T) {
 	assert.Nil(t, err)
 
 	qc := NewQueryCursor()
-	qc.Exec(q, root, []byte(js))
+	qc.Exec(q, root)
 
 	var matched int
 	for {
@@ -378,7 +378,7 @@ func testCaptures(t *testing.T, body, sq string, expectedMatchCount int, expecte
 	assert.Nil(err)
 
 	qc := NewQueryCursor()
-	qc.Exec(q, root, []byte(body))
+	qc.Exec(q, root)
 
 	matches := 0
 	actual := []string{}
@@ -771,7 +771,7 @@ func TestCursorKeepsQuery(t *testing.T) {
 
 		qc := NewQueryCursor()
 
-		qc.Exec(query, root, source)
+		qc.Exec(query, root)
 
 		for {
 			// ensure qc.NextMatch() doesn't  cause a segfault
@@ -840,7 +840,7 @@ func TestQueryMatch_satisfiesTextPredicates(t *testing.T) {
 
 		q, _ := NewQuery([]byte(testCase.query), getTestGrammar())
 		qc := NewQueryCursor()
-		qc.Exec(q, root, []byte(testCase.input))
+		qc.Exec(q, root)
 
 		qm, ok := qc.nextMatch(false)
 		assert.True(t, ok)
@@ -855,7 +855,7 @@ func TestQueryMatch_satisfiesTextPredicates(t *testing.T) {
 
 		q, _ = NewQuery([]byte(inverseQuery), getTestGrammar())
 		qc = NewQueryCursor()
-		qc.Exec(q, root, []byte(testCase.input))
+		qc.Exec(q, root)
 
 		qm, ok = qc.nextMatch(false)
 		assert.True(t, ok)

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -974,7 +974,7 @@ func TestFilterPredicates(t *testing.T) {
 		assert.True(t, ok)
 		assert.Len(t, before.Captures, testCase.expectedBefore, fmt.Sprintf("test num %d failed", testNum))
 
-		after := qc.FilterPredicates(before)
+		after := qc.filterPredicates(before)
 		assert.Len(t, after.Captures, testCase.expectedAfter, fmt.Sprintf("test num %d failed", testNum))
 	}
 }

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -341,7 +341,7 @@ func TestQuery(t *testing.T) {
 	q, err := NewQuery([]byte("(sum) (number)"), getTestGrammar())
 	assert.Nil(t, err)
 
-	qc := NewQueryCursor()
+	qc := NewQueryCursor([]byte(js))
 	qc.Exec(q, root)
 
 	var matched int
@@ -369,7 +369,7 @@ func testCaptures(t *testing.T, body, sq string, expected []string) {
 	q, err := NewQuery([]byte(sq), getTestGrammar())
 	assert.Nil(err)
 
-	qc := NewQueryCursor()
+	qc := NewQueryCursor([]byte(body))
 	qc.Exec(q, root)
 
 	actual := []string{}
@@ -844,7 +844,7 @@ func TestCursorKeepsQuery(t *testing.T) {
 			getTestGrammar(),
 		)
 
-		qc := NewQueryCursor()
+		qc := NewQueryCursor(source)
 
 		qc.Exec(query, root)
 
@@ -967,14 +967,14 @@ func TestFilterPredicates(t *testing.T) {
 		root := tree.RootNode()
 
 		q, _ := NewQuery([]byte(testCase.query), getTestGrammar())
-		qc := NewQueryCursor()
+		qc := NewQueryCursor([]byte(testCase.input))
 		qc.Exec(q, root)
 
-		before, ok := qc.NextMatch()
+		before, ok := qc.nextMatch(false)
 		assert.True(t, ok)
 		assert.Len(t, before.Captures, testCase.expectedBefore, fmt.Sprintf("test num %d failed", testNum))
 
-		after := qc.FilterPredicates(before, []byte(testCase.input))
+		after := qc.FilterPredicates(before)
 		assert.Len(t, after.Captures, testCase.expectedAfter, fmt.Sprintf("test num %d failed", testNum))
 	}
 }

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -341,8 +341,8 @@ func TestQuery(t *testing.T) {
 	q, err := NewQuery([]byte("(sum) (number)"), getTestGrammar())
 	assert.Nil(t, err)
 
-	qc := NewQueryCursor([]byte(js))
-	qc.Exec(q, root)
+	qc := NewQueryCursor()
+	qc.Exec(q, root, []byte(js))
 
 	var matched int
 	for {
@@ -369,8 +369,8 @@ func testCaptures(t *testing.T, body, sq string, expected []string) {
 	q, err := NewQuery([]byte(sq), getTestGrammar())
 	assert.Nil(err)
 
-	qc := NewQueryCursor([]byte(body))
-	qc.Exec(q, root)
+	qc := NewQueryCursor()
+	qc.Exec(q, root, []byte(body))
 
 	actual := []string{}
 	for {
@@ -844,9 +844,9 @@ func TestCursorKeepsQuery(t *testing.T) {
 			getTestGrammar(),
 		)
 
-		qc := NewQueryCursor(source)
+		qc := NewQueryCursor()
 
-		qc.Exec(query, root)
+		qc.Exec(query, root, source)
 
 		for {
 			// ensure qc.NextMatch() doesn't  cause a segfault
@@ -967,8 +967,8 @@ func TestFilterPredicates(t *testing.T) {
 		root := tree.RootNode()
 
 		q, _ := NewQuery([]byte(testCase.query), getTestGrammar())
-		qc := NewQueryCursor([]byte(testCase.input))
-		qc.Exec(q, root)
+		qc := NewQueryCursor()
+		qc.Exec(q, root, []byte(testCase.input))
 
 		before, ok := qc.nextMatch(false)
 		assert.True(t, ok)


### PR DESCRIPTION
Updated to match ~~https://docs.rs/tree-sitter/latest/tree_sitter/struct.QueryCursor.html#method.matches~~ https://www.npmjs.com/package/tree-sitter

Most notably: input text is stored on the `Tree` so `Node` can use it in `Content()` to return the node text without extra inputs.