### PR TITLE
Attempts to fix an issue where multiple predicates can't be used in a…

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -829,6 +829,9 @@ func (q *Query) PredicatesForPattern(patternIndex uint32) []QueryPredicateStep {
 		stepType := QueryPredicateStepType(s._type)
 		valueId := uint32(s.value_id)
 		predicateSteps = append(predicateSteps, QueryPredicateStep{stepType, valueId})
+		if stepType == QueryPredicateStepTypeDone {
+			break
+		}
 	}
 
 	return predicateSteps

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -829,6 +829,20 @@ func TestQueryMatch_satisfiesTextPredicates(t *testing.T) {
 		(#eq? @left @right))`,
 			expected: false,
 		},
+		{
+			input: `
+			// foo
+			
+			// bar
+			
+			// baz`,
+			query: `(
+		(comment) @capture1 (#match? @capture1 "^// foo")
+		(comment) @capture2 (#match? @capture2 "^// bar$")
+		(comment) @capture3 (#eq? @capture3 "// baz")
+		)`,
+			expected: true,
+		},
 	}
 
 	parser := NewParser()


### PR DESCRIPTION
This PR is an initial attempt at resolving an issue where multiple predicates an a query results in a panic.

In Klotho, we see the following error:

```
 error [err 0] Error constructing query for (class_declaration body:
  (declaration_list (
                      (method_declaration
                        name : (_) @method_name (#eq? @method_name "Configure")
                        parameters: (parameter_list (
                                                      (parameter
                                                        type: (_) @param_type (#eq? @param_type "IApplicationBuilder")
                                                        name: (_) @param_name
                                                        )
                                                      )
                                      )
                        ) @method_declaration
                      )
    )) @class_declaration: wrong number of arguments to `#eq?` predicate. Expected 2, got 6
 error Klotho compilation failed     
```